### PR TITLE
reflect move from /about to /learn on the portal

### DIFF
--- a/source/getting-started/index.rst
+++ b/source/getting-started/index.rst
@@ -30,9 +30,9 @@ On your first Chameleon login you will be asked to accept `terms and conditions
 note that as part of those terms and conditions you are requested to acknowledge
 Chameleon in publications you produced using the testbed: see our FAQ for
 information on `how to reference Chameleon in your publications
-<https://www.chameleoncloud.org/about/frequently-asked-questions/#toc-how-should-i-reference-chameleon->`_
+<https://www.chameleoncloud.org/learn/frequently-asked-questions/#toc-how-should-i-reference-chameleon->`_
 and the suggested `acknowledgement text
-<https://www.chameleoncloud.org/about/frequently-asked-questions/#toc-how-should-i-acknowledge-chameleon-in-my-publications->`_.
+<https://www.chameleoncloud.org/learn/frequently-asked-questions/#toc-how-should-i-acknowledge-chameleon-in-my-publications->`_.
 
 Once you log in, you will be able to :ref:`edit your Chameleon profile
 <profile-page>`, sign up for webinars, and participate in our community.
@@ -130,7 +130,7 @@ a bare metal node.
 
    Do not attempt to stack reservations to circumvent the 7-day lease
    limitation. Your leases may be deleted. Please refer to our `best practices
-   <https://www.chameleoncloud.org/about/frequently-asked-questions/#toc-what-are-the-best-practices-of-chameleon-usage->`_
+   <https://www.chameleoncloud.org/learn/frequently-asked-questions/#toc-what-are-the-best-practices-of-chameleon-usage->`_
    if you require a longer reservation.
 
 Launching an instance

--- a/source/user/federation.rst
+++ b/source/user/federation.rst
@@ -88,7 +88,7 @@ Signing in to your legacy account
 ---------------------------------
 
 Until `December 1st, 2020
-<https://www.chameleoncloud.org/about/frequently-asked-questions/#toc-what-is-the-schedule-for-migration-to-federated-identity->`_,
+<https://www.chameleoncloud.org/learn/frequently-asked-questions/#toc-what-is-the-schedule-for-migration-to-federated-identity->`_,
 you will be able to log in to your legacy Chameleon account to access leases or
 server instances you created in the past. Use the login option "Go to the old
 sign in page" to access your legacy account via the old username/password login.

--- a/source/user/federation/federation_migration.rst
+++ b/source/user/federation/federation_migration.rst
@@ -8,7 +8,7 @@ Federated login enables users to use a single set of credentials to log into
 many different services. For example, federated login allows you to use your
 institutional credentials to log into Chameleon--there is no need to create a
 new account. To leverage its `many benefits
-<https://www.chameleoncloud.org/about/frequently-asked-questions/#toc-why-did-chameleon-move-to-federated-login->`_,
+<https://www.chameleoncloud.org/learn/frequently-asked-questions/#toc-why-did-chameleon-move-to-federated-login->`_,
 Chameleon is migrating to federated identity and will eventually drop support
 for signing in via legacy Chameleon accounts. Existing Chameleon users can link
 their existing Chameleon account to a federated identity account so that they
@@ -16,12 +16,12 @@ preserve their project memberships, disk images, volumes, SSH key pairs, and
 other data saved over time.
 
 To ease the transition, during the `migration period
-<https://www.chameleoncloud.org/about/frequently-asked-questions/#toc-what-is-the-schedule-for-migration-to-federated-identity->`_
+<https://www.chameleoncloud.org/learn/frequently-asked-questions/#toc-what-is-the-schedule-for-migration-to-federated-identity->`_
 you can log in via your old Chameleon account as well as the federated account.
 Existing users however are highly encouraged to migrate to a federated account
 as soon as possible. Read more about federated identity, how it has been
 implemented, as well as the migration schedule in `our FAQ
-<https://www.chameleoncloud.org/about/frequently-asked-questions/#toc-federated-login>`_.
+<https://www.chameleoncloud.org/learn/frequently-asked-questions/#toc-federated-login>`_.
 
 .. important::
 

--- a/source/user/project.rst
+++ b/source/user/project.rst
@@ -76,7 +76,7 @@ resource (physical hosts, network segments, or floating IPs). For example, a
 reservation for 5 Haswell compute nodes for 8 hours would use 40 SUs. However,
 for certain types of resources, more SUs will be charged. For more details about
 allocation charges, please see `here
-<https://www.chameleoncloud.org/about/frequently-asked-questions/#toc-what-are-the-units-of-an-allocation-and-how-am-i-charged->`_.
+<https://www.chameleoncloud.org/learn/frequently-asked-questions/#toc-what-are-the-units-of-an-allocation-and-how-am-i-charged->`_.
 
 .. _project-details:
 


### PR DESCRIPTION
we have some broken links.

I'm not sure of our deploy method for these docs though.