### PR TITLE
add actions for linting

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,0 +1,25 @@
+name: lint
+
+on:
+  push:
+
+jobs:
+  doc8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Install Deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - uses: reviewdog/action-setup@v1
+      - name: lint with reviewdog
+        env:
+            REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tox q -e lint | reviewdog \
+          -efm "%f:%l: %m" \
+          -diff "git diff FETCH_HEAD" \
+          -filter-mode file \
+          -reporter=github-check

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-rstcheck
+doc8
 sphinx
 sphinx-autobuild
 sphinx-rtd-theme

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,19 @@
 [tox]
 skipsdist = True
 
-[testenv]
+[testenv:lint]
 basepython = python3
 setenv = LANGUAGE=en_US
          LC_ALL=en_US.UTF-8
 passenv = http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY
-deps =
-    -r requirements.txt
-whitelist_externals = make
-commands = make {posargs:livehtml}
+deps = -r requirements.txt
+whitelist_externals = doc8
+commands = doc8 -q source
+
+[testenv:build]
+commands = sphinx-build -b html source build/html
+
+[doc8]
+max-line-length = 100
+; ignore = D001,D002,D003,D005
+ignore = D001


### PR DESCRIPTION
This runs "doc8" against "source", and then filters the output based on whether the file was in the last commit.

This specified doc8 rather than rstcheck, as rstcheck apparently doesn't support more recent versions of sphinx, and did not catch the code-block issues we encountered in recent tickets.