### PR TITLE
Remove references to OpenStack train

### DIFF
--- a/source/getting-started-edge/index.rst
+++ b/source/getting-started-edge/index.rst
@@ -155,7 +155,7 @@ add in the new changes for edge devices
 
 .. code-block:: shell
 
-  pip install git+https://github.com/chameleoncloud/python-blazarclient@chameleoncloud/stable/train
+  pip install git+https://github.com/chameleoncloud/python-blazarclient@chameleoncloud/xena
 
 Be sure to use the the OpenStack RC file downloaded from the Edge site, which
 means you should be logged into the GUI at

--- a/source/technical/cli.rst
+++ b/source/technical/cli.rst
@@ -57,7 +57,7 @@ OpenStack Client Installation
 
    .. code-block:: shell
 
-      pip install git+https://github.com/chameleoncloud/python-blazarclient@chameleoncloud/stable/train
+      pip install git+https://github.com/chameleoncloud/python-blazarclient@chameleoncloud/xena
 
 .. _cli-authentication:
 

--- a/source/technical/kvm.rst
+++ b/source/technical/kvm.rst
@@ -8,7 +8,7 @@ Introduction
 
 OpenStack is an Infrastructure as a Service (IaaS) platform that allows you to
 create and manage virtual environments. Chameleon provides an installation of
-OpenStack `Train <https://releases.openstack.org/train/index.html>`_ using the
+OpenStack `Xena <https://releases.openstack.org/xena/index.html>`_ using the
 KVM virtualization technology at the `KVM\@TACC
 <https://kvm.tacc.chameleoncloud.org>`_ site. Since the KVM hypervisor is used
 on this cloud, any virtual machines you upload must be compatible with KVM.
@@ -277,7 +277,7 @@ Next, issue the following command:
 
 Details and other options for this command are available via the Glance
 `image-create-via-import documentation
-<https://docs.openstack.org/python-glanceclient/train/cli/details.html#glance-image-create-via-import>`_.
+<https://docs.openstack.org/python-glanceclient/xena/cli/details.html#glance-image-create-via-import>`_.
 
 .. attention::
    Glance image-create-via-import is currently unable to handle conversion of

--- a/source/technical/reservations.rst
+++ b/source/technical/reservations.rst
@@ -279,7 +279,7 @@ CLI, you must install the ``python-blazarclient``. To install
 
 .. code-block:: bash
 
-   pip install git+https://github.com/ChameleonCloud/python-blazarclient.git@chameleoncloud/stable/train
+   pip install git+https://github.com/ChameleonCloud/python-blazarclient.git@chameleoncloud/xena
 
 .. note::
    To reserve VLAN segments or floating IPs, you must use a Chameleon fork of


### PR DESCRIPTION
Since our sites are now upgraded to Xena, we should not be telling
people to install software or read docs from Train.
