### PR TITLE
doc for cli `reservation lease show`

### DIFF
--- a/source/technical/reservations.rst
+++ b/source/technical/reservations.rst
@@ -451,6 +451,40 @@ For example, you can use ``resource_properties='["=", "$architecture.smp_size",
 
 .. note:: Remember to use ``$`` in front of the property.
 
+
+Showing Lease Details
+---------------------
+
+To display detailed information about a specific lease,
+you can use the `openstack reservation lease show` command.
+By default, this command provides basic lease information
+such as name, status, and duration. However, if you want to
+view all the resources allocated within the lease,
+you can use the `--detail` option.
+
+.. code-block:: bash
+
+   openstack reservation lease show LEASE_NAME_OR_ID
+
+To display all resource allocations within the lease, use the `--detail` option:
+
+.. code-block:: bash
+
+   openstack reservation lease show --detail LEASE_NAME_OR_ID
+
+Example:
+
+.. code-block:: bash
+
+   openstack reservation lease show --detail my-first-lease
+
+Expected Output:
+
+The output will include detailed information about the lease, including the
+resources reserved within it such as hosts, networks, and devices.
+
+
+
 Extending a Lease
 -----------------
 


### PR DESCRIPTION
Added documentation for showing lease details and displaying all resource allocations within a lease in the Blazar CLI documentation under the "Provisioning and Managing Resources Using the CLI" section. Updated the documentation with instructions, examples, and expected output for using the openstack reservation lease show command with the --detail option.

<img width="718" alt="image" src="https://github.com/ChameleonCloud/docs/assets/20154899/733f91a6-20b3-4036-a45e-44bc0c3546f1">
